### PR TITLE
fix: Ensure media files are served in production

### DIFF
--- a/Django/locapro_project/urls.py
+++ b/Django/locapro_project/urls.py
@@ -50,4 +50,10 @@ if settings.DEBUG:
 else:
     # In production, also serve static files through Django for the static homepage assets
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # Note: static() returns empty list when DEBUG=False
+
+# Always serve media files explicitly (for platforms without separate media storage)
+# This ensures uploaded profile photos and request photos are accessible
+urlpatterns += [
+    re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
+]


### PR DESCRIPTION
- Added explicit media file serving using re_path and serve view
- Fixes profile photos and uploaded images not displaying in production
- The static() helper returns empty list when DEBUG=False
- This ensures /media/ URLs work regardless of DEBUG setting